### PR TITLE
fix: 修改有误的sh输出

### DIFF
--- a/docs/linux/cli/linux-cli-dir.md
+++ b/docs/linux/cli/linux-cli-dir.md
@@ -18,7 +18,7 @@ Linux 系统是一种典型的多用户系统，不同的用户处于不同的�
 ```bash
 $ ls -l
 total 64
-dr-xr-xr-x 2 root root 4096 Dec 14 2012 bin
+drwxr-xr-x 2 root root 4096 Dec 14 2012 bin
 dr-xr-xr-x 4 root root 4096 Apr 19 2012 boot
 ```
 
@@ -52,7 +52,7 @@ dr-xr-xr-x 4 root root 4096 Apr 19 2012 boot
 ```bash
 $ ls -l
 total 64
-dr-xr-xr-x   2 root root 4096 Dec 14  2012 bin
+drwxr-xr-x   2 root root 4096 Dec 14  2012 bin
 dr-xr-xr-x   4 root root 4096 Apr 19  2012 boot
 ```
 


### PR DESCRIPTION
# 文件属性的sh结果和对应的教程文字未对应
## 问题描述
对于bin文件来讲，如果按照教程文字中所讲，其参数应为`drwxr-xr-x`
## 解决方案
修改sh输出结果使其与教程中文字所匹配。