### PR TITLE
fix: Docker教程下的路由跳转失败 & 其他子页面logo显示错误

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ hs_err_pid*
 # maven plugin temp files
 .flattened-pom.xml
 package-lock.json
-
+pnpm-lock.yaml
 
 # ------------------------------- javascript -------------------------------
 # dependencies
@@ -50,11 +50,9 @@ yarn-error.log*
 bundle*.js
 book.pdf
 
-
 # ------------------------------- intellij -------------------------------
 .idea
 *.iml
-
 
 # ------------------------------- eclipse -------------------------------
 .classpath

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -15,7 +15,7 @@ module.exports = {
     },
   },
   themeConfig: {
-    logo: 'images/dunwu-logo-100.png',
+    logo: '/images/dunwu-logo-100.png',
     repo: 'dunwu/linux-tutorial',
     repoLabel: 'Github',
     docsDir: 'docs',

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -2,10 +2,10 @@
 
 ## 📖 内容
 
-- [Docker 快速入门](docker/docker-quickstart.md)
-- [Dockerfile 最佳实践](docker/docker-dockerfile.md)
-- [Docker Cheat Sheet](docker/docker-cheat-sheet.md)
-- [Kubernetes 应用指南](docker/kubernetes.md)
+- [Docker 快速入门](docker-quickstart.md)
+- [Dockerfile 最佳实践](docker-dockerfile.md)
+- [Docker Cheat Sheet](docker-cheat-sheet.md)
+- [Kubernetes 应用指南](kubernetes.md)
 
 ## 📚 资料
 


### PR DESCRIPTION
##  Docker教程下的路由跳转失败：
![CleanShot 2024-03-12 at 18 27 56](https://github.com/dunwu/linux-tutorial/assets/53571741/276b044b-0f12-47d7-b93d-00fa06a7864a)
## 其他子页面logo显示错误：
<img width="1038" alt="image" src="https://github.com/dunwu/linux-tutorial/assets/53571741/efbfc269-f236-4b05-8182-8bd16d194dd5">
